### PR TITLE
Install Logstash for RedHat family distributions

### DIFF
--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -12,3 +12,9 @@
     gpgcheck: yes
     enabled: yes
     file: logstash
+
+- name: Install Logstash package.
+  yum: name=logstash update_cache=yes state=latest
+
+- name: Configure Logstash.
+  include: logstash.yml


### PR DESCRIPTION
Update configuration to yum install and start Logstash on RedHat family
distributions.

Add's the missing steps necessary to install and start LogStash.